### PR TITLE
Import ZFS pool by partlabel

### DIFF
--- a/nixos/system/configuration.nix
+++ b/nixos/system/configuration.nix
@@ -9,6 +9,7 @@ in {
   boot.loader.efi.canTouchEfiVariables = true;
   # /Copy
   boot.supportedFilesystems = [ "zfs" ];
+  boot.zfs.devNodes = "/dev/disk/by-partlabel";
   boot.zfs.extraPools = [ "data" ];
 
   time.timeZone = "Etc/UTC";


### PR DESCRIPTION
Otherwise `zpool status` reverts to showing wwn IDs after a reboot.