### PR TITLE
Send stdout from the installer script to the console

### DIFF
--- a/nixos/configuration-installer.nix
+++ b/nixos/configuration-installer.nix
@@ -109,6 +109,7 @@ in {
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = "yes";
+      StandardOutput = "journal+console";
     };
 
     script = ''


### PR DESCRIPTION
And stderr will default to going the same place. This resolves #20.