### PR TITLE
Make the admin user member of an admins group

### DIFF
--- a/nixos/system/default.nix
+++ b/nixos/system/default.nix
@@ -36,11 +36,15 @@ in {
 
   users.mutableUsers = false;
 
+  users.groups.admins = {
+    gid = 1000;
+  };
+
   users.users."${variables.adminUser}" = {
     isNormalUser = true;
     uid = 1000;
     description = "Primary admin user";
-    extraGroups = ["wheel"];
+    extraGroups = [ "wheel" "admins" ];
     openssh.authorizedKeys.keys = [ variables.adminSshPublicKey ];
   };
 


### PR DESCRIPTION
The admin user should be able to copy files over SSH so make a group  for them and I'll make give it access to some dirs in ZFS (outside the scope of our NixOS configs).