### PR TITLE
Enable hardware acceleration

### DIFF
--- a/nixos/system/default.nix
+++ b/nixos/system/default.nix
@@ -67,4 +67,17 @@ in {
   ];
 
   programs.tmux.enable = true;
+
+  nixpkgs.config.packageOverrides = pkgs: {
+    vaapiIntel = pkgs.vaapiIntel.override { enableHybridCodec = true; };
+  };
+  hardware.opengl = {
+    enable = true;
+    extraPackages = with pkgs; [
+      intel-media-driver
+      vaapiIntel
+      vaapiVdpau
+      libvdpau-va-gl
+    ];
+  };
 }


### PR DESCRIPTION
Pulled straight from the NixOS wiki. Future improvements:

- Only do this if it's an Intel CPU
- Enable nvenc if there's an Nvidia GPU