### PR TITLE
Add the intel-compute-runtime package

### DIFF
--- a/nixos/system/default.nix
+++ b/nixos/system/default.nix
@@ -78,6 +78,7 @@ in {
       vaapiIntel
       vaapiVdpau
       libvdpau-va-gl
+      intel-compute-runtime
     ];
   };
 }


### PR DESCRIPTION
This is for hardware accelerated HDR->SDR tone mapping, per: https://nixos.wiki/wiki/Jellyfin

Although, https://jellyfin.org/docs/general/administration/hardware-acceleration/intel/ makes it sound like QuickSync does it better...?

I really need to learn more about these Intel drivers. Seems like some of these options may be redundant.