### PR TITLE
Put a very basic flake at the top of the config

### DIFF
--- a/nixos/configuration-installer.nix
+++ b/nixos/configuration-installer.nix
@@ -144,7 +144,8 @@ in {
       # Use the generated hardware-configuration.nix.
       nixos-generate-config --root /mnt
 
-      cp -r /nix/store/*-nasty-0.1.0/lib/nasty /mnt/etc/nasty
+      cp -r /nix/store/*-nasty-0.1.0/lib/nasty /mnt/etc/nixos/
+      cp /mnt/etc/nasty/nixos/flake.nix /mnt/etc/nixos/
       cp /mnt/etc/nasty/nixos/configuration.nix /mnt/etc/nixos/
 
       nixos-install --no-root-passwd

--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707863367,
+        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "A very NASty system configuration";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }: let
+    variables = import ./nasty/nixos/variables/system.nix;
+  in {
+    nixosConfigurations = {
+      "${variables.hostName}" = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [ ./configuration.nix ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
It seems that switching to a flake-based install means it goes it a sort of chroot in the nix store during a `nixos-rebuild` and `import ../whatever` no longer works, so the nasty repo clone needs to go in `/etc/nixos/`.