### PR TITLE
Remove the top-level configuration.nix file

### DIFF
--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -38,7 +38,7 @@ jobs:
           NIXOS_ADMIN_SSH_PUBLIC_KEY: ${{ vars.nixos_admin_ssh_public_key }}
         run: |
           nix-shell -p nixos-generators \
-            --run "nixos-generate -f install-iso -c ${{ github.workspace }}/nixos/configuration-installer.nix -o result"
+            --run "nixos-generate -f install-iso -c ${{ github.workspace }}/nixos/installer.nix -o result"
           echo "artifact_build_time=$(date -u +%Y-%m-%dT%H_%M_%S)" >> $GITHUB_OUTPUT
           echo "artifact_digest=$(readlink result | cut -d '/' -f 4 | cut -d '-' -f 1)" >> $GITHUB_OUTPUT
           echo "artifact_path=$(readlink result)" >> $GITHUB_OUTPUT

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -1,7 +1,0 @@
-{config, pkgs, ...}: let
-in {
-  imports = [
-    ./hardware-configuration.nix
-    ../nasty/nixos
-  ];
-}

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -11,7 +11,10 @@
     nixosConfigurations = {
       "${variables.hostName}" = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        modules = [ ./configuration.nix ];
+        modules = [
+          ./hardware-configuration.nix
+          ./nasty/nixos
+        ];
       };
     };
   };

--- a/nixos/installer.nix
+++ b/nixos/installer.nix
@@ -146,7 +146,6 @@ in {
 
       cp -r /nix/store/*-nasty-0.1.0/lib/nasty /mnt/etc/nixos/
       cp /mnt/etc/nasty/nixos/flake.nix /mnt/etc/nixos/
-      cp /mnt/etc/nasty/nixos/configuration.nix /mnt/etc/nixos/
 
       nixos-install --no-root-passwd
 


### PR DESCRIPTION
It's redundant now, we can just do the import from the `flake.nix`.