### PR TITLE
Create the Grafana Cloud stack

### DIFF
--- a/tf/monitoring.tf
+++ b/tf/monitoring.tf
@@ -1,4 +1,7 @@
-data "grafana_cloud_stack" "test" {
+resource "grafana_cloud_stack" "main" {
   provider = grafana.cloud
-  slug     = var.grafana_cloud_slug
+
+  name        = var.grafana_cloud_slug
+  slug        = var.grafana_cloud_slug
+  region_slug = var.grafana_cloud_region
 }

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -26,6 +26,10 @@ variable "grafana_cloud_token" {
 variable "grafana_cloud_slug" {
   description = "Name of the Grafana Cloud stack to manage (https://<slug>.grafana.net)"
 }
+variable "grafana_cloud_region" {
+  description = "Region slug the Grafana Cloud stack will be located in"
+  default     = "prod-us-west-0"
+}
 
 variable "pagerduty_admin_email" {
   description = "The admin user's PagerDuty email address"


### PR DESCRIPTION
I stopped grafana-agent on the NAS and deleted the old stack so I can manage it with TF instead.