### PR TITLE
Create two acceess policies and import a dashboard

### DIFF
--- a/tf/monitoring.tf
+++ b/tf/monitoring.tf
@@ -5,3 +5,41 @@ resource "grafana_cloud_stack" "main" {
   slug        = var.grafana_cloud_slug
   region_slug = var.grafana_cloud_region
 }
+
+resource "grafana_cloud_access_policy" "metrics_publisher" {
+  provider = grafana.cloud
+  region = var.grafana_cloud_region
+
+  name = "metrics-publisher"
+  display_name = "Metrics Publisher"
+  scopes = ["metrics:write"]
+
+  realm {
+    type = "stack"
+    identifier = grafana_cloud_stack.main.id
+  }
+}
+
+resource "grafana_cloud_access_policy" "logs_publisher" {
+  provider = grafana.cloud
+  region = var.grafana_cloud_region
+
+  name = "logs-publisher"
+  display_name = "Logs Publisher"
+  scopes = ["metrics:write"]
+
+  realm {
+    type = "stack"
+    identifier = grafana_cloud_stack.main.id
+  }
+}
+
+# TODO: TF can manage the tokens if I can figure out how to have it feed them
+# into an Agenix secrets file.
+
+resource "grafana_dashboard_public" "node_exporter_full" {
+  provider = grafana.stack
+
+  dashboard_uid = "1860-node-exporter-full"
+  is_enabled = true
+}

--- a/tf/providers.tf
+++ b/tf/providers.tf
@@ -27,6 +27,11 @@ provider "grafana" {
   cloud_access_policy_token = var.grafana_cloud_token
 }
 
+provider "grafana" {
+  alias = "stack"
+  url = grafana_cloud_stack.main.url
+}
+
 provider "pagerduty" {
   token = var.pagerduty_api_key
 }


### PR DESCRIPTION
I *think* this is what I need to do. The Grafana Cloud UI still offers a link to create an "API key" for publishing metrics, but API keys are deprecated and I'm a bit confused on "access policy tokens" vs "service account tokens".