### PR TITLE
Create a Grafana notif policy

### DIFF
--- a/tf/monitoring.tf
+++ b/tf/monitoring.tf
@@ -74,6 +74,13 @@ resource "grafana_contact_point" "main" {
   }
 }
 
+resource "grafana_notification_policy" "main" {
+  provider = grafana.stack
+
+  contact_point = grafana_contact_point.main.name
+  group_by      = ["grafana_folder", "alertname"]
+}
+
 data "http" "grafana_dashboard_node_exporter" {
   url = "https://grafana.com/api/dashboards/1860/revisions/${var.grafana_dashboard_node_exporter_revision}/download"
 }


### PR DESCRIPTION
If I understand the docs right, this should replace the default non-functional global policy with one that hits our admin contact.