### PR TITLE
Only listen on localhost for the metrics entrypoint

### DIFF
--- a/nixos/traefik/default.nix
+++ b/nixos/traefik/default.nix
@@ -29,7 +29,7 @@ in {
 
     entryPoints = {
       metrics = {
-        address = ":8081"
+        address = "localhost:8081";
       };
 
       https = {


### PR DESCRIPTION
The scraping is being done by Grafana Agent on the localhost, it doesn't need to listen for everything. The port's not open in the firewall anyway, but just in case.