### PR TITLE
Move ports to a variables file

### DIFF
--- a/nixos/installer.nix
+++ b/nixos/installer.nix
@@ -57,7 +57,7 @@ in {
 
         # Make sure generated files don't accidentally get committed to git.
         pushd $out/lib/nasty
-        git update-index --assume-unchanged nixos/hardware-configuration.nix nixos/variables/*.nix
+        git update-index --assume-unchanged nixos/hardware-configuration.nix nixos/variables/system.nix
         popd
       '';
     })

--- a/nixos/traefik/default.nix
+++ b/nixos/traefik/default.nix
@@ -1,5 +1,6 @@
 {config, pkgs, agenix, secrets, ...}: let
   variables = import ../variables/system.nix;
+  ports = import ../variables/ports.nix;
 in {
   environment.systemPackages = with pkgs; [
     traefik
@@ -29,11 +30,11 @@ in {
 
     entryPoints = {
       metrics = {
-        address = "localhost:8081";
+        address = "localhost:${ports.traefik.metrics}";
       };
 
       https = {
-        address = ":443";
+        address = ":${ports.traefik.https}";
         http = {
           tls = {
             domains = [
@@ -48,7 +49,7 @@ in {
       };
 
       http = {
-        address = ":80";
+        address = ":${ports.traefik.http}";
         http.redirections.entryPoint = {
           to = "https";
         };
@@ -88,5 +89,5 @@ in {
 
   services.traefik.enable = true;
 
-  networking.firewall.allowedTCPPorts = [ 80 443 ];
+  networking.firewall.allowedTCPPorts = [ ports.http ports.https ];
 }

--- a/nixos/variables/ports.nix
+++ b/nixos/variables/ports.nix
@@ -1,0 +1,5 @@
+traefik = {
+  https = 443;
+  http = 80;
+  metrics = 8081;
+};


### PR DESCRIPTION
Not necessarily because I'll be wanting to change them, but some services may need to know about others' ports.

Leaving Jellyfin's 8096 hardcoded for now because the Nix package doesn't allow reconfiguring the port.