### PR TITLE
Return a 403 for /metrics instead of 404 + clean up

### DIFF
--- a/nixos/traefik/default.nix
+++ b/nixos/traefik/default.nix
@@ -59,29 +59,13 @@ in {
 
   services.traefik.dynamicConfigOptions = {
     http = {
-      services = {
-        jellyfin.loadBalancer.servers = [ { url = "http://127.0.0.1:${ports.jellyfin.web}"; } ];
-      };
-
-      routers = {
-        jellyfin-https = {
-          rule = "PathPrefix(`/`) && !PathPrefix(`/health`) && !PathPrefix(`/metrics`)";
-          entryPoints = [ "https" ];
-          service = "jellyfin";
-          tls = {
-            domains = [
-              {
-                main = variables.domain;
-                sans = [ "*.${variables.domain}" ];
-              }
-            ];
-            certresolver = "letsencrypt";
-          };
+      middlewares.forbidden = {
+        ipWhiteList = {
+          sourceRange = [ "127.0.0.1/32" ];
         };
       };
     };
   };
-
 
   systemd.services.traefik.serviceConfig = {
     EnvironmentFile = [ config.age.secrets.traefik-env.path ];


### PR DESCRIPTION
Because of the way NixOS merges configs, services can "register" themselves with Traefik instead of everything being defined in Traefik's module.

Returning a 403 forbidden is more correct. The allowlist middleware won't accept an empty IP list or I'd have forbidden it from everywhere.

Also removes the now-redundant TLS configs since they're now being set globally in the static config.