### PR TITLE
Add an access policy to GFC for traces

### DIFF
--- a/tf/modules/monitoring/grafana_cloud.tf
+++ b/tf/modules/monitoring/grafana_cloud.tf
@@ -49,3 +49,17 @@ resource "grafana_cloud_access_policy" "logs_publisher" {
     identifier = grafana_cloud_stack.main.id
   }
 }
+
+resource "grafana_cloud_access_policy" "traces_publisher" {
+  provider = grafana.cloud
+  region   = var.grafana_cloud_region
+
+  name         = "traces-publisher"
+  display_name = "Traces Publisher"
+  scopes       = ["traces:write"]
+
+  realm {
+    type       = "stack"
+    identifier = grafana_cloud_stack.main.id
+  }
+}


### PR DESCRIPTION
I want to experiment with trace data too. Going to start by shipping Traefik -> Grafana Agent -> Grafana Cloud/Tempo.

I want to test OpenTelemetry Collector and Honeycomb as well, but Honeycomb has a less generous free tier (only 2 alerts) so probably won't full replace.