### PR TITLE
Start sending traces from Traefik -> Grafana Agent -> Grafana Cloud

### DIFF
--- a/nixos/grafana/default.nix
+++ b/nixos/grafana/default.nix
@@ -40,7 +40,7 @@
     };
 
     traces.configs = [{
-      name = "traefik";
+      name = "default";
 
       remote_write = [{
         endpoint = "\${TRACES_REMOTE_WRITE_ENDPOINT}";
@@ -48,9 +48,7 @@
         basic_auth.password_file = "\${CREDENTIALS_DIRECTORY}/traces_remote_write_password";
       }];
 
-      receivers.jaeger = {
-        protocols = { grpc = {}; };
-      };
+      receivers.jaeger.protocols.thrift_compact = { };
     }];
   };
 

--- a/nixos/traefik/monitoring.nix
+++ b/nixos/traefik/monitoring.nix
@@ -1,6 +1,18 @@
 {config, pkgs, ...}: let
   ports = import ../variables/ports.nix;
 in {
+  services.traefik.staticConfigOptions.entryPoints.metrics = {
+    address = "localhost:${toString ports.traefik.metrics}";
+  };
+
+  services.traefik.staticConfigOptions.metrics = {
+    prometheus = {
+      entryPoint = "metrics";
+    };
+  };
+
+  services.traefik.staticConfigOptions.tracing = { };
+
   services.grafana-agent.settings.metrics.configs = [
     {
       name = "traefik";


### PR DESCRIPTION
Also changes the metrics entrypoint to only listen on localhost (just in case).