### PR TITLE
Add a node label to all metrics

### DIFF
--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1707830867,
-        "narHash": "sha256-PAdwm5QqdlwIqGrfzzvzZubM+FXtilekQ/FA0cI49/o=",
+        "lastModified": 1712079060,
+        "narHash": "sha256-/JdiT9t+zzjChc5qQiF+jhrVhRt8figYH29rZO7pFe4=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "8cb01a0e717311680e0cbca06a76cbceba6f3ed6",
+        "rev": "1381a759b205dff7a6818733118d02253340fd5e",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711523803,
-        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
+        "lastModified": 1712439257,
+        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
+        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
         "type": "github"
       },
       "original": {

--- a/nixos/grafana/default.nix
+++ b/nixos/grafana/default.nix
@@ -1,5 +1,6 @@
-{config, pkgs, agenix, secrets, ...}:
-{
+{config, pkgs, agenix, variables, secrets, ...}: let
+  vars = import variables;
+in {
   environment.systemPackages = with pkgs; [
     grafana-agent
   ];
@@ -37,6 +38,10 @@
       }];
 
       scrape_interval = "60s";
+
+      external_labels = {
+        node = "${vars.hostName}.${vars.domain}";
+      };
     };
 
     traces.configs = [{

--- a/tf/modules/monitoring/grafana_dashboards/node_info.json.tftpl
+++ b/tf/modules/monitoring/grafana_dashboards/node_info.json.tftpl
@@ -264,7 +264,7 @@
           "type": "prometheus",
           "uid": "$${datasource}"
         },
-        "definition": "label_values(node_uname_info{job=\"$job\"}, instance)",
+        "definition": "label_values(node_uname_info{job=\"$job\"}, node)",
         "hide": 0,
         "includeAll": false,
         "label": "Host",
@@ -272,7 +272,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(node_uname_info{job=\"$job\"}, instance)",
+          "query": "label_values(node_uname_info{job=\"$job\"}, node)",
           "refId": "Prometheus-node-Variable-Query"
         },
         "refresh": 1,

--- a/tf/modules/monitoring/grafana_dashboards/node_info.json.tftpl
+++ b/tf/modules/monitoring/grafana_dashboards/node_info.json.tftpl
@@ -227,36 +227,6 @@
       {
         "current": {
           "selected": false,
-          "text": "integrations/node_exporter",
-          "value": "integrations/node_exporter"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$${datasource}"
-        },
-        "definition": "",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Job",
-        "multi": false,
-        "name": "job",
-        "options": [],
-        "query": {
-          "query": "label_values(node_uname_info, job)",
-          "refId": "Prometheus-job-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "selected": false,
           "text": "default",
           "value": "default"
         },
@@ -264,7 +234,7 @@
           "type": "prometheus",
           "uid": "$${datasource}"
         },
-        "definition": "label_values(node_uname_info{job=\"$job\"}, node)",
+        "definition": "label_values(node_uname_info, node)",
         "hide": 0,
         "includeAll": false,
         "label": "Host",
@@ -272,7 +242,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(node_uname_info{job=\"$job\"}, node)",
+          "query": "label_values(node_uname_info, node)",
           "refId": "Prometheus-node-Variable-Query"
         },
         "refresh": 1,


### PR DESCRIPTION
I want dashboards with metrics that come from the NAS, regardless of which scrape "instance" they came from. The instance label is a poor choice for this since I could be any of "hostname:port", "localhost:port", etc.