### PR TITLE
Replace uses of the now-deleted $job variable

### DIFF
--- a/tf/modules/monitoring/grafana_dashboards.tf
+++ b/tf/modules/monitoring/grafana_dashboards.tf
@@ -8,7 +8,15 @@ locals {
   panels_updated = {
     for panel in local.panels_orig : panel.title => merge(
       panel,
-      { targets = [for target in panel.targets : merge(target, { expr = replace(target.expr, "instance", "node") })] }
+      {
+        targets = [
+          for target in panel.targets : merge(
+            target, {
+              expr = replace(replace(target.expr, "instance", "node"), "$job", "integrations/node_exporter")
+            }
+          )
+        ]
+      }
     )
   }
 }


### PR DESCRIPTION
The only job these know about is "integrations/node_exporter" and that name doesn't change.