### PR TITLE
(Temporarily) disable the ZFS scrub

### DIFF
--- a/nixos/system/default.nix
+++ b/nixos/system/default.nix
@@ -13,7 +13,7 @@ in {
   boot.zfs.devNodes = "/dev/disk/by-partlabel";
   boot.zfs.extraPools = [ "data" ];
   servies.zfs.autoScrub = {
-    enable = true;
+    enable = false;
     interval = "*-01,04,07,10-01 07:00:00";
   };
 


### PR DESCRIPTION
Guess how I found out that the PCIe SATA controller I'm running four drives off of fails under heavy load? Running a scrub results in all four drives vanishing from the system.

Thankfully, I thought to arrange the drives so these four disappearing only degrades the pool rather than destroying it. Turning this back off until I order a new card (LSI 9207-i8?) and verify that it can handle a scrub.